### PR TITLE
[codex] Clarify project terminology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,13 +9,13 @@ cmake_install.cmake
 compile_commands.json
 
 # Binaries
-bf_bst
-flipdist
-flipdist_fast
-flipdist_asan
-test
-test_fast
-test_asan
+/bf_bst
+/flipdist
+/flipdist_fast
+/flipdist_asan
+/test
+/test_fast
+/test_asan
 
 # Debug symbols
 *.dSYM/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(Summer25_Research LANGUAGES CXX)
+project(ExactFlipDistanceResearch LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FlipDist Research Solver
+# Exact Flip Distance Research Code
 
 FlipDist is a research implementation of an exact solver for flip distance on rooted binary trees, equivalently rotation distance between binary trees or flip distance between triangulations of a convex polygon. The solver is built on the fixed-parameter algorithmic framework of Li and Xia, "An O(3.82^k) Time FPT Algorithm for Convex Flip Distance" (STACS 2023).
 
@@ -35,7 +35,7 @@ The current practical limit evidence is summarized in `docs/hard-limit-analysis.
 | `n=26..27` | Practical boundary; latest full `0..100` coverage is improved but still below 90% under `2s`. |
 | `n=28+` | Current Li-Xia-structured solver is not reliable under the strict `2s` cap. |
 
-The bottleneck is still `TreeDistS/S.empty()`: hard cases repeatedly explore rotation children and partition-side checks. Local exact budget-probe tuning and ordering improvements help timing-margin cases, but the retained sweeps suggest that 90%-plus coverage through n=27 under `2s` would require a deeper structural improvement.
+The bottleneck is still `TreeDistS/S.empty()`: complex cases repeatedly explore rotation children and partition-side checks. Local exact budget-probe tuning and ordering improvements help timing-margin cases, but the retained sweeps suggest that 90%-plus coverage through n=27 under `2s` would require a deeper structural improvement.
 
 ## Quick Start
 
@@ -62,6 +62,8 @@ Small parity check against the Java oracle:
 tests/java_parity.sh
 ```
 
+New readers may want `docs/terminology.md` first. It defines terms such as simple case, complex case, directed row, combined directed coverage, timeout, and hard-limit analysis.
+
 ## Directory Map
 
 | Path | Purpose |
@@ -81,6 +83,7 @@ tests/java_parity.sh
 
 - `docs/architecture.md`: solver components and Li-Xia flow.
 - `docs/references.md`: primary paper citation and problem background.
+- `docs/terminology.md`: plain-language definitions for benchmark and solver terms.
 - `docs/benchmarks.md`: maintained benchmark and parity commands.
 - `docs/hard-limit-analysis.md`: current hard-limit, hard-case profile, and AStar comparison evidence.
 - `docs/development.md`: build/test workflow and contribution expectations.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,9 +20,9 @@ Convex polygon triangulations and rooted full binary trees are equivalent repres
 
 ## Source Layout
 
-`src/flipdist/main.cpp` is the `flipdist` CLI entrypoint. It delegates argument parsing, random/comb generation, file input, and JSON-lines output to `testing_cli.*`.
+`src/flipdist/main.cpp` is the `flipdist` CLI entrypoint. It delegates argument parsing, random/simple-case generation, file input, and JSON-lines output to `testing_cli.*`.
 
-`src/flipdist/bf_bst.*` contains the binary-tree representation, rotation helpers, random/comb construction, canonical serialization, and the `bf_bst` brute-force validator binary.
+`src/flipdist/bf_bst.*` contains the binary-tree representation, rotation helpers, random/simple construction, canonical serialization, and the `bf_bst` brute-force validator binary.
 
 `src/flipdist/algorithm.*` contains the main exact solver flow. The important parts are:
 
@@ -37,7 +37,7 @@ Convex polygon triangulations and rooted full binary trees are equivalent repres
 
 The public `flipdist` binary emits two directed rows for each case: `a->b` and `b->a`. Each row reports `case_type`, `n`, `seed`, `direction`, `distance`, `time_ms`, `status`, tree encodings, and `max_k`.
 
-The search remains complete for the configured `max_k`. Optimization work should preserve the distance definition, output fields, status meanings, and Li-Xia decomposition. Current bottleneck work is concentrated in `TreeDistS`, where repeated split exploration and partition budget loops dominate hard random cases.
+The search remains complete for the configured `max_k`. Optimization work should preserve the distance definition, output fields, status meanings, and Li-Xia decomposition. Current bottleneck work is concentrated in `TreeDistS`, where repeated split exploration and partition budget loops dominate complex random cases.
 
 ## Validation Layers
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -2,6 +2,8 @@
 
 This page records the benchmark and parity commands used to evaluate the FlipDist research solver. The retained metrics are intended to make the implementation reproducible and to separate exactness checks from performance measurements.
 
+See `docs/terminology.md` for plain-language definitions of directed rows, combined directed coverage, simple cases, complex cases, timeouts, and other benchmark terms.
+
 Run all commands from the repository root after building with CMake or `./setup.sh`.
 
 ## Fast Validation Wrappers
@@ -277,7 +279,7 @@ python3 tools/plot_flipdist_vs_astar_compare.py \
   --summary-output results/shared_convex_flipdist_vs_astar_n22_25_seeds0_100_timeout10_summary.csv
 ```
 
-A local no-Gurobi AStar build can be used for `simple` and `combined` comparisons when Gurobi is unavailable, but the checkout and patch stay under ignored `third_party/`. The current local comparable summary is retained in `benchmarks/shared_convex_local_flipdist_vs_astar_n22_30_summary.csv`.
+A local no-Gurobi AStar build can be used for AStarFlipDistance `simple` and `combined` algorithm comparisons when Gurobi is unavailable, but the checkout and patch stay under ignored `third_party/`. These are external A* algorithm names, not project case names. The current local comparable summary is retained in `benchmarks/shared_convex_local_flipdist_vs_astar_n22_30_summary.csv`.
 
 The local summary was produced from two bounded sweeps:
 
@@ -309,6 +311,6 @@ When timeout subsets differ, prefer paired-row medians over raw solved-case medi
 
 ## Metric Notes
 
-Random sweep rows are directed. A single generated seed normally produces `a->b` and `b->a` rows. Directed coverage counts both rows. Pair coverage counts the seed only when both directions return `ok`.
+Random sweep rows are directed. A single generated seed normally produces `a->b` and `b->a` rows. Directed coverage counts both rows. Pair coverage counts the seed only when both directions return `ok`. Combined directed coverage is the same directed-row calculation after grouping multiple sizes or runs together.
 
 `status=ok` means the exact solver found a distance within the configured `max_k`. `status=timeout` means the Python harness stopped the run at the configured wall-clock cap. In the full hard-limit sweep, the cap is applied to the `flipdist` process for one seed; if the process does not return both JSON rows before the cap, the harness records both directions as timeout. Timing near a fixed threshold such as 2s can vary slightly between runs and machines.

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,7 @@ tests/script_help.py
 
 ## Optimization Guidelines
 
-The current implementation bottleneck is `TreeDistS` in `S.empty()`. Hard cases spend most of their time repeating partition-side checks and budget-loop work. Changes in this area should be paired with:
+The current implementation bottleneck is `TreeDistS` in `S.empty()`. Complex cases spend most of their time repeating partition-side checks and budget-loop work. Changes in this area should be paired with:
 
 - Java parity on feasible oracle ranges.
 - A random sweep sanity run for `n=23..25`, seeds `0..20`.

--- a/docs/hard-limit-analysis.md
+++ b/docs/hard-limit-analysis.md
@@ -1,6 +1,6 @@
 # Hard-Limit Analysis
 
-This page summarizes the current empirical limits of the FlipDist implementation. It is written for researchers and collaborators who need to understand what the solver can reproduce, where the retained benchmarks start to fail under fixed time caps, and which bottlenecks remain open.
+This page summarizes the current empirical limits of the FlipDist implementation. It is written for researchers and collaborators who need to understand what the solver can reproduce, where the retained benchmarks start to fail under fixed time caps, and which bottlenecks remain open. Definitions for benchmark terms are in `docs/terminology.md`.
 
 The implementation is based on the Li-Xia exact FPT framework for Convex Flip Distance; see `docs/references.md`. FlipDist remains an exact solver for the configured `max_k`. A timeout does not imply an incorrect distance; it means the process did not finish within the benchmark cap.
 
@@ -26,7 +26,7 @@ The maintained baseline remains `n=23..25`, seeds `0..100`, timeout `2.5s`, `max
 
 Combined directed coverage is `576/606 = 95.0%`. This is the stable baseline range for the current solver.
 
-A fresh validation run on this build recorded `n=23: 198/202`, `n=24: 184/202`, and `n=25: 192/202`. The only row-level difference from the retained baseline was n=24 seed `24`, which solved in `2395.958 ms` in the retained run and now lands around `2.57s` when forced through the easier direction. This is another strict-time timing-margin case. The compact validation summary is retained in `benchmarks/random_n23_25_profile_instrumented_validation_summary.csv`.
+A fresh validation run on this build recorded `n=23: 198/202`, `n=24: 184/202`, and `n=25: 192/202`. The only row-level difference from the retained baseline was n=24 seed `24`, which solved in `2395.958 ms` in the retained run and now lands around `2.57s` when forced through the lower-cost direction. This is another strict-time timing-margin case. The compact validation summary is retained in `benchmarks/random_n23_25_profile_instrumented_validation_summary.csv`.
 
 ## 99% Baseline Attempt
 
@@ -131,7 +131,7 @@ Operationally, the bottleneck appears as follows:
 1. The solver reaches a state where many rotations are possible.
 2. Many rotations lead to similar-looking subproblems.
 3. The solver repeatedly splits those subproblems into partition sides.
-4. Hard cases create hundreds of thousands of repeated recursive checks before the 2s cap expires.
+4. Complex cases create hundreds of thousands of repeated recursive checks before the 2s cap expires.
 
 The current implementation already uses safe caching, child-state deduplication, lower-bound reuse, and direction ordering. These reduce some repeated work, but they do not remove the core growth in the empty-`S` branch.
 
@@ -145,7 +145,7 @@ The first n=26..27 boundary pass improved the smaller seeds `0..20` slice by cha
 | After direction lock | 2s | 40/42 = 95.2% | 36/42 = 85.7% | 76/84 = 90.5% |
 | Empty-S pair-bound propagation | 2s | 40/42 = 95.2% | 36/42 = 85.7% | 76/84 = 90.5% |
 
-That improvement came from solving timing-margin cases earlier. It did not fix the persistent hard seeds.
+That improvement came from solving timing-margin cases earlier. It did not fix the persistent complex seeds.
 
 The latest full `0..100` boundary pass added a narrower shape-based direction rule. It recovered seven previously timed-out seed pairs without changing exact distances or the Li-Xia search:
 
@@ -165,12 +165,12 @@ Profile evidence for `n=27 seed=83` shows what the budget-probe tuning fixed. Si
 
 For example, before the patch, `n=27 seed=32` entered the hard `a->b` direction first and aborted after more than `346,000` `TreeDistS` calls, `160,000` empty-`S` calls, and `128,000` partition calls. After the patch, it starts with `b->a`, solves in about `336 ms`, and the reverse direction reuses the exact result immediately.
 
-Persistent hard seeds in the smaller slice:
+Persistent complex seeds in the smaller slice:
 
 - `n=26`: seed `14`.
 - `n=27`: seeds `5`, `9`, and `14`.
 
-Profile samples still show the same bottleneck. After the direction patch, persistent hard seeds still abort at 5s with very high recursive pressure. Profile times are accumulated across recursive calls, so a counter can be larger than wall-clock time.
+Profile samples still show the same bottleneck. After the direction patch, persistent complex seeds still abort at 5s with very high recursive pressure. Profile times are accumulated across recursive calls, so a counter can be larger than wall-clock time.
 
 | Profile | Direction | TreeDistS calls | Empty-S calls | Partition calls | Accumulated budget-loop time |
 |---|---|---:|---:|---:|---:|

--- a/docs/research-notes.md
+++ b/docs/research-notes.md
@@ -4,7 +4,7 @@ These notes summarize the current research state without replacing the detailed 
 
 ## Primary Reference
 
-The implementation builds on Haohong Li and Ge Xia, "An O(3.82^k) Time FPT Algorithm for Convex Flip Distance" (STACS 2023). The paper gives the algorithmic foundation for the exact fixed-parameter search; this repository focuses on an implementation, validation against an independent oracle, and empirical hard-case analysis.
+The implementation builds on Haohong Li and Ge Xia, "An O(3.82^k) Time FPT Algorithm for Convex Flip Distance" (STACS 2023). The paper gives the algorithmic foundation for the exact fixed-parameter search; this repository focuses on an implementation, validation against an independent oracle, and empirical complex-case analysis.
 
 See `docs/references.md` for citation links.
 
@@ -19,7 +19,7 @@ FlipDist is an exact solver for rooted binary-tree flip distance. Work in this r
 
 ## Current Bottleneck
 
-The persistent hard cases concentrate in `TreeDistS` when `S` is empty. Timing-margin improvements from direction ordering and exact budget-probe tuning help selected seeds, but the retained n=23..27 evidence shows many remaining misses still create large amounts of new branch growth.
+The persistent complex cases concentrate in `TreeDistS` when `S` is empty. Timing-margin improvements from direction ordering and exact budget-probe tuning help selected seeds, but the retained n=23..27 evidence shows many remaining misses still create large amounts of new branch growth.
 
 See `docs/hard-limit-analysis.md` for the current hard-limit evidence and `docs/benchmarks.md` for regeneration commands.
 

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,0 +1,46 @@
+# Terminology
+
+This page defines project terms in plain language. It is intended for readers who want to run the solver or read benchmark summaries before studying the implementation.
+
+## Problem Terms
+
+| Term | Meaning |
+| --- | --- |
+| Flip distance | The minimum number of local moves needed to transform one convex polygon triangulation into another. |
+| Rotation distance | The same problem viewed on rooted binary trees. A flip in a triangulation corresponds to a rotation in a binary tree. |
+| Rooted binary tree | The tree representation used by the C++ solver. Each generated case contains two such trees. |
+| Triangulation | A way to split a convex polygon into triangles using non-crossing diagonals. The Java oracle uses this view. |
+| Exact solver | A solver that returns the true distance when it finishes within the configured search budget. |
+| `max_k` | The largest distance value the exact search is asked to consider. If the true distance is above `max_k`, the run may report `not_found`. |
+
+## Case Terms
+
+| Term | Meaning |
+| --- | --- |
+| Case | One generated or file-provided pair of trees. |
+| Random case | A case generated from two seeded random binary-search-tree insertion orders. Most retained benchmarks use random cases. |
+| Simple case | A structured generated case using opposite chain-shaped trees. The CLI also accepts the older name `comb` for compatibility. |
+| Complex case | A case that is empirically difficult for the current implementation, usually because it causes many recursive branches before the time cap. |
+| Seed | The integer used to regenerate the same random case. |
+| Direction | The solver checks each tree pair both ways: `a->b` and `b->a`. These can take different amounts of time even though the exact distance is symmetric. |
+
+## Benchmark Terms
+
+| Term | Meaning |
+| --- | --- |
+| Directed row | One result for one direction of one case. A random seed normally produces two directed rows: `a->b` and `b->a`. |
+| Directed solves | The number of directed rows with `status=ok`. |
+| Combined directed coverage | The directed solves across several sizes or benchmarks divided by all directed rows in that group. For example, `576/606 = 95.0%` means 576 of 606 directional runs finished exactly. |
+| Solved pair | A seed where both directions finish with `status=ok`. |
+| Timeout | The harness stopped the process at the configured wall-clock cap. A timeout is not an incorrect distance. |
+| Timing-margin case | A case that finishes very close to a benchmark timeout, so it may cross the cap on another machine or run. |
+| Hard-limit analysis | The empirical study of where this implementation stops meeting target coverage under fixed time caps. It is not a mathematical impossibility proof. |
+| Curated benchmark summary | A compact CSV retained in `benchmarks/` because it supports a documented project claim. Raw generated outputs stay in ignored `results/`. |
+
+## External Comparison Terms
+
+| Term | Meaning |
+| --- | --- |
+| AStarFlipDistance | Optional external solver used only for comparison. It is not part of the tracked project source. |
+| A* `simple` / `combined` | Algorithm labels used by AStarFlipDistance. They are external names and are kept unchanged in comparison scripts and CSV columns. |
+| Paired-row median | A median computed only on rows where both compared solvers produced usable results. This avoids misleading comparisons when timeout subsets differ. |

--- a/src/flipdist/testing_cli.cpp
+++ b/src/flipdist/testing_cli.cpp
@@ -447,9 +447,14 @@ struct CliOptions {
 // Returns: nothing
 // Errors: none
 static void printUsage(const char *argv0) {
-    std::cerr << "Usage: " << argv0 << " --case random|comb --n <int> [--seed <int>] [--count <int>]\n"
+    std::cerr << "Usage: " << argv0 << " --case random|simple|comb --n <int> [--seed <int>] [--count <int>]\n"
               << "       [--max-k <int>] [--bfs-cap <int>] [--print-trees] [--emit-path] [--path-ascii]\n"
-              << "   or: " << argv0 << " --tree-a-file <path> --tree-b-file <path> [--max-k <int>] [--print-trees]\n";
+              << "   or: " << argv0 << " --tree-a-file <path> --tree-b-file <path> [--max-k <int>] [--print-trees]\n"
+              << "   Note: --case simple is the clearer alias for the older --case comb.\n";
+}
+
+static bool isSimpleGeneratedCase(const std::string &case_type) {
+    return case_type == "simple" || case_type == "comb";
 }
 
 // Definition: Parse CLI flags into CliOptions
@@ -739,8 +744,8 @@ int runCli(int argc, char **argv) {
         std::cerr << "Invalid --count\n";
         return 2;
     }
-    if (!custom_inputs && opts.case_type != "random" && opts.case_type != "comb") {
-        std::cerr << "Invalid --case (use random or comb)\n";
+    if (!custom_inputs && opts.case_type != "random" && !isSimpleGeneratedCase(opts.case_type)) {
+        std::cerr << "Invalid --case (use random, simple, or comb)\n";
         return 2;
     }
 

--- a/tools/generate_shared_convex_instances.py
+++ b/tools/generate_shared_convex_instances.py
@@ -20,7 +20,12 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate shared convex-polygon benchmark instances for FlipDist and A*"
     )
-    parser.add_argument("--case", choices=["random", "comb"], default="random")
+    parser.add_argument(
+        "--case",
+        choices=["random", "simple", "comb"],
+        default="random",
+        help="'simple' is the clearer alias for the older 'comb'.",
+    )
     parser.add_argument("--n", type=int, required=True, help="Number of BST nodes / number of triangles")
     parser.add_argument("--seed-min", type=int, default=0, help="First seed to generate")
     parser.add_argument("--seed-max", type=int, default=0, help="Last seed to generate")
@@ -203,6 +208,8 @@ def generate_case(case_type: str, n: int, seed: int) -> tuple[tuple[list[int], l
 
 def main() -> int:
     cfg = parse_args()
+    if cfg.case == "comb":
+        cfg.case = "simple"
     if cfg.n <= 0:
         raise SystemExit("--n must be positive")
     if cfg.seed_max < cfg.seed_min:

--- a/tools/research_archive/sweep_plateau_taxonomy.py
+++ b/tools/research_archive/sweep_plateau_taxonomy.py
@@ -19,7 +19,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--seed-min", type=int, default=0)
     parser.add_argument("--seed-max", type=int, default=0)
     parser.add_argument("--cpp-binary", default="./build/flipdist")
-    parser.add_argument("--case", dest="case_type", choices=["random", "comb"], default="random")
+    parser.add_argument(
+        "--case",
+        dest="case_type",
+        choices=["random", "simple", "comb"],
+        default="random",
+        help="'simple' is the clearer alias for the older 'comb'.",
+    )
     parser.add_argument("--timeout-sec", type=float, default=10.0)
     parser.add_argument("--max-k-mult", type=int, default=2)
     parser.add_argument("--raw-dir", required=True, help="Directory for raw profile outputs")
@@ -36,6 +42,8 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     cfg = parse_args()
+    if cfg.case_type == "comb":
+        cfg.case_type = "simple"
     raw_dir = Path(cfg.raw_dir)
     raw_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tools/run_flipdist_java_parity.py
+++ b/tools/run_flipdist_java_parity.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Parity harness: C++ FlipDist vs Java BFS (triangulation oracle).
 
-This runs the C++ `flipdist` CLI to generate random/comb tree pairs and
+This runs the C++ `flipdist` CLI to generate random or simple tree pairs and
 computes the exact flip distance using the Java BFS implementation
 (`TriangulationMetricsCli`). It then reports any distance mismatches.
 """
@@ -175,7 +175,13 @@ def maybe_prompt_output(cfg) -> None:
 
 def parse_args():
     p = argparse.ArgumentParser(description="Verify C++ flipdist against Java BFS oracle.")
-    p.add_argument("--case", dest="case_type", choices=["comb", "random"], default="random")
+    p.add_argument(
+        "--case",
+        dest="case_type",
+        choices=["random", "simple", "comb"],
+        default="random",
+        help="'simple' is the clearer alias for the older 'comb'.",
+    )
     p.add_argument("--n", type=int, required=True)
     p.add_argument("--count", type=int, default=1)
     p.add_argument("--seed", type=int, default=0)
@@ -206,6 +212,8 @@ def parse_args():
 
 def main() -> int:
     cfg = parse_args()
+    if cfg.case_type == "comb":
+        cfg.case_type = "simple"
     if cfg.n > cfg.max_java_n and not cfg.allow_java_n_over:
         raise SystemExit(
             f"Refusing to run Java BFS at n={cfg.n} (max {cfg.max_java_n}). "

--- a/tools/run_flipdist_java_parity_sweep.py
+++ b/tools/run_flipdist_java_parity_sweep.py
@@ -16,7 +16,13 @@ from pathlib import Path
 
 def parse_args():
     p = argparse.ArgumentParser(description="Sweep FlipDist vs Java BFS parity across n/seeds.")
-    p.add_argument("--case", dest="case_type", choices=["comb", "random"], default="random")
+    p.add_argument(
+        "--case",
+        dest="case_type",
+        choices=["random", "simple", "comb"],
+        default="random",
+        help="'simple' is the clearer alias for the older 'comb'.",
+    )
     p.add_argument("--n-min", type=int, required=True)
     p.add_argument("--n-max", type=int, required=True)
     p.add_argument("--seed-min", type=int, default=0)
@@ -111,6 +117,8 @@ def run_one(cfg, n: int, seed: int, out_csv: Path) -> int:
 
 def main() -> int:
     cfg = parse_args()
+    if cfg.case_type == "comb":
+        cfg.case_type = "simple"
     if cfg.n_max < cfg.n_min:
         raise SystemExit("--n-max must be >= --n-min")
     if cfg.seed_max < cfg.seed_min:

--- a/tools/run_shared_convex_flipdist_vs_astar_sweep.py
+++ b/tools/run_shared_convex_flipdist_vs_astar_sweep.py
@@ -17,7 +17,12 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Generate shared convex instances and compare FlipDist vs A* on the exact same inputs"
     )
-    parser.add_argument("--case", choices=["random", "comb"], default="random")
+    parser.add_argument(
+        "--case",
+        choices=["random", "simple", "comb"],
+        default="random",
+        help="'simple' is the clearer alias for the older 'comb'.",
+    )
     parser.add_argument("--n-min", type=int, required=True)
     parser.add_argument("--n-max", type=int, required=True)
     parser.add_argument("--seed-min", type=int, default=0)
@@ -88,7 +93,12 @@ def parse_algos(raw: str) -> list[str]:
     return sorted(set(algos))
 
 
+def canonical_case_type(case_type: str) -> str:
+    return "simple" if case_type == "comb" else case_type
+
+
 def generate_shared_case(root: Path, case_type: str, n: int, seed: int) -> dict[str, Path | str | int]:
+    case_type = canonical_case_type(case_type)
     case_dir = root / f"n_{n}" / f"set_{seed}"
     tri_dir = case_dir / "triangulation"
     tri_dir.mkdir(parents=True, exist_ok=True)
@@ -295,6 +305,7 @@ def remaining_timeout(deadline: float | None) -> float | None:
 
 def main() -> int:
     cfg = parse_args()
+    cfg.case = canonical_case_type(cfg.case)
     if cfg.n_max < cfg.n_min:
         raise SystemExit("--n-max must be >= --n-min")
     if cfg.seed_max < cfg.seed_min:

--- a/tools/sweep_flipdist_limits.py
+++ b/tools/sweep_flipdist_limits.py
@@ -2,7 +2,7 @@
 """Sweep FlipDist runtime limits across n and seeds.
 
 This is a performance harness (not a correctness oracle). It runs the C++
-`flipdist` CLI on random or comb cases across a range of n and seeds,
+`flipdist` CLI on random or simple generated cases across a range of n and seeds,
 records per-direction status/time, and prints a per-n summary.
 
 Example:
@@ -42,7 +42,13 @@ def float_list(arg: str) -> list[float]:
 
 def parse_args():
     p = argparse.ArgumentParser(description="Sweep FlipDist performance across n/seeds.")
-    p.add_argument("--case", dest="case_type", choices=["random", "comb"], default="random")
+    p.add_argument(
+        "--case",
+        dest="case_type",
+        choices=["random", "simple", "comb"],
+        default="random",
+        help="Generated case type. 'simple' is the clearer alias for the older 'comb'.",
+    )
     p.add_argument("--n-min", type=int, required=True)
     p.add_argument("--n-max", type=int, required=True)
     p.add_argument("--seed-min", type=int, default=0, help="Only used for --case random")
@@ -235,6 +241,8 @@ def invoke_flipdist(cfg, n: int, seed: int, max_k: int, timeout_sec: float, bfs_
 
 def main() -> int:
     cfg = parse_args()
+    if cfg.case_type == "comb":
+        cfg.case_type = "simple"
     out_path = resolve_output_path(cfg)
     if out_path:
         out_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Follow-up terminology cleanup after the research handoff refactor.

- Renames the project-facing title to `Exact Flip Distance Research Code` and the CMake project to `ExactFlipDistanceResearch`.
- Adds `docs/terminology.md` with plain-language definitions for terms such as simple case, complex case, directed row, combined directed coverage, timeout, timing-margin case, and hard-limit analysis.
- Adds `simple` as a clearer generated-case alias while keeping legacy `comb` accepted by the C++ CLI and Python tools.
- Updates docs to use `complex cases` in place of informal hard/easy wording where appropriate.
- Fixes `.gitignore` binary patterns so root binaries are ignored without matching `src/flipdist/`.

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build -j`
- `tests/smoke.sh`
- `ctest --test-dir build --output-on-failure`
- `tests/script_help.py --include-archive`
- `./build/flipdist --case simple --n 6 --count 1 --max-k 30 --bfs-cap 1`
- `./build/flipdist --case comb --n 6 --count 1 --max-k 30 --bfs-cap 1`
- `python3 tools/sweep_flipdist_limits.py --case simple --n-min 6 --n-max 6 --timeout-sec 2 --max-k-mult 3 --cpp-binary ./build/flipdist --output results/simple_alias_smoke.csv`
- `git diff --check`